### PR TITLE
trailers are bigger in smaller devices and are responsive

### DIFF
--- a/src/components/details/Trailers.jsx
+++ b/src/components/details/Trailers.jsx
@@ -17,7 +17,7 @@ export default function Trailers({ details }) {
       {/* Centered Video Container */}
       <div className="flex justify-center">
         {/* Embed YouTube Video */}
-        <div className="w-full max-w-[70%] sm:max-w-[33%] aspect-video">
+        <div className="w-full max-w-[95%] sm:max-w-[80%] md:max-w-[60%] lg:max-w-[50%] xl:max-w-[40%] aspect-video">
           <iframe
             src={`https://www.youtube.com/embed/${trailer.key}`}
             title={trailer.name}


### PR DESCRIPTION
Trailers now responsive and are bigger in smaller media

- mark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the video display layout for a smoother, more responsive viewing experience across all device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->